### PR TITLE
Switch to Maven Central: README + POM metadata, release 1.1.0

### DIFF
--- a/combot/build.gradle.kts
+++ b/combot/build.gradle.kts
@@ -75,7 +75,7 @@ mavenPublishing {
             developer {
                 id.set("GabrielBrasileiro")
                 name.set("Gabriel Brasileiro")
-                url.set("https://github.com/GabrielBrasileiro/")
+                url.set("https://gabrielbrasileiro.dev")
             }
         }
 

--- a/combot/build.gradle.kts
+++ b/combot/build.gradle.kts
@@ -61,7 +61,7 @@ mavenPublishing {
         name.set("Combot")
         description.set("A declarative Android UI testing library for creating and managing Compose test flows easily.")
         inceptionYear.set("2025")
-        url.set("https://github.com/GabrielBrasileiro/combot/")
+        url.set("https://gabrielbrasileiro.dev/combot")
 
         licenses {
             license {

--- a/combot/build.gradle.kts
+++ b/combot/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "io.github.gabrielbrasileiro"
-version = "1.0.13"
+version = "1.1.0"
 
 android {
     namespace = "br.com.gabrielbrasileiro.combot"

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 ![Kotlin](https://img.shields.io/badge/Kotlin-2.2.21-blue)
 ![GitHub Actions](https://github.com/GabrielBrasileiro/combot/actions/workflows/main.yml/badge.svg?branch=main)
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue)
-![JitPack](https://img.shields.io/jitpack/version/com.github.GabrielBrasileiro/combot.svg?color=blue)
+![Maven Central](https://img.shields.io/maven-central/v/io.github.gabrielbrasileiro/combot.svg?color=blue)
 
 ## Description
 
@@ -29,8 +29,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        // Add for your project
-        maven { url = uri("https://jitpack.io") }
     }
 }
 ```
@@ -38,7 +36,7 @@ dependencyResolutionManagement {
 ### Gradle Kts
 
 ```kotlin
-implementation("com.github.GabrielBrasileiro:combot:x.x.x")
+implementation("io.github.gabrielbrasileiro:combot:x.x.x")
 ```
 
 ### Gradle Toml + Kts
@@ -48,7 +46,7 @@ implementation("com.github.GabrielBrasileiro:combot:x.x.x")
 combot = "x.x.x"
 
 [libraries]
-combot = { group = "com.github.GabrielBrasileiro", name = "combot", version.ref = "combot" }
+combot = { group = "io.github.gabrielbrasileiro", name = "combot", version.ref = "combot" }
 ```
 
 ```kotlin

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
+        // Add for your project if not declared
         mavenCentral()
     }
 }


### PR DESCRIPTION
## Summary
Combot now publishes to Maven Central under `io.github.gabrielbrasileiro`. This PR updates docs and POM metadata to match, and bumps the version so merging cuts the 1.1.0 release.

### README
- Replace JitPack version badge with the Maven Central badge
- Remove the `jitpack.io` repository from the install snippet
- Add a `// Add for your project if not declared` note above `mavenCentral()`
- Update install coordinates to `io.github.gabrielbrasileiro`

### POM metadata (combot/build.gradle.kts)
- Project `url` → `https://gabrielbrasileiro.dev/combot` (docs site)
- Developer `url` → `https://gabrielbrasileiro.dev` (personal site)
- SCM URLs left on GitHub (must point at the git repo)

### Release
- Bump version `1.0.13` → `1.1.0`

## Note
Merging to `main` triggers the publish workflow, which tags `1.1.0` and releases it to Maven Central.